### PR TITLE
Renames rake task to data:seed_fake and fixes it to run only on development environment and to only add new facilities

### DIFF
--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -22,7 +22,7 @@ namespace :data do
 
     result = []
     new_facilities.map do |facility_hash|
-      next if Facility.find_by(id: facility_hash['id']).present?
+      next if Facility.find_by(id: facility_hash["id"]).present?
 
       result << Facility.create(facility_hash)
     end

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -5,6 +5,8 @@ namespace :data do
   #    rake json:export[./db/facilities.json]
   desc "export active facilities to a JSON file"
   task load_fake: :environment do
+    abort "This script can only be run on development environment" unless Rails.env.development?
+
     logger = Rails.logger
     logger.extend(ActiveSupport::Logger.broadcast(ActiveSupport::Logger.new(STDOUT)))
     logger.formatter = nil

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -3,33 +3,33 @@
 namespace :data do
   # Usage Example:
   #    rake json:export[./db/facilities.json]
-  desc "export active facilities to a JSON file"
-  task load_fake: :environment do
+  desc "Create facilities from db/fake_data.json JSON file"
+  task seed_fake: :environment do
     abort "This script can only be run on development environment" unless Rails.env.development?
 
     logger = Rails.logger
     logger.extend(ActiveSupport::Logger.broadcast(ActiveSupport::Logger.new(STDOUT)))
     logger.formatter = nil
 
-    logger.info "[load_fake] Loading new facilities from database."
+    logger.info "[seed_fake] Loading new facilities from database."
     new_facilities = load_fake_data.dig("v1", "facilities")
     if new_facilities.blank?
-      logger.error "[load_fake] Failed to load new facilities."
+      logger.error "[seed_fake] Failed to load new facilities."
       abort
     end
 
-    logger.info "[load_fake] Removing old facilities from database."
-    result = Facility.all.map(&:destroy)
-    unless result.all?
-      logger.error "[load_fake] Failed to remove facilities."
-      abort
+    logger.info "[seed_fake] Creating #{new_facilities.count} facilities."
+
+    result = []
+    new_facilities.map do |facility_hash|
+      next if Facility.find_by(id: facility_hash['id']).present?
+
+      result << Facility.create(facility_hash)
     end
 
-    logger.info "[load_fake] Creating #{new_facilities.count} facilities."
-    result = new_facilities.map { |facility_hash| Facility.create(facility_hash) }
-    logger.error "[load_fake] Failed to add facilities." unless result.all?
+    logger.error "[seed_fake] Failed to add facilities." unless result.all?
 
-    logger.info "[load_fake] Done creating facilities."
+    logger.info "[seed_fake] Done creating facilities."
   end
 
   def load_fake_data


### PR DESCRIPTION
Running `rails data:seed_fake` will populate local database from `db/fake_data.json` file.

Now, this is not a destructive action, and therefore, facilities with same ID as facilities in the JSON file are not touched.